### PR TITLE
chore - Add support for child node in <iframe>

### DIFF
--- a/src/iframe.tsx
+++ b/src/iframe.tsx
@@ -11,7 +11,7 @@ const Iframe: ComponentType<IIframe>
 			 frameBorder, ariaHidden, sandbox, allow,
 			 className, title, ariaLabel, ariaLabelledby,
 			 name, target, loading, importance, referrerpolicy,
-			 allowpaymentrequest, src
+			 allowpaymentrequest, src, children
 		 }: IIframe) => {
 
 	const defaultProps = objectAssign({
@@ -70,7 +70,9 @@ const Iframe: ComponentType<IIframe>
 			props.style.border = frameBorder
 		}
 	}
-	return <iframe {...props}/>
+	return <iframe {...props}>
+	{children}
+</iframe>
 
 }
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+import React from "react"
+
 export interface IIframe {
 	url: string,
 	src?: string,
@@ -27,4 +29,5 @@ export interface IIframe {
 	allow?: string,
 	className?: string,
 	title?: string
+	children?: React.ReactNode,
 }


### PR DESCRIPTION
For the purpose of accessibility, it is generally expected that the contents within an iframe contain some fallback behavior or text that indicates that the given site/functionality relies on iframes to work. Tools such as Compliance-Sheriff and other accessibility audit checkers raise an error if iframes do not contain some content within it describing the iframe.

This only gets rendered / read on browsers that do not support iframes. 