### PR TITLE
Sandbox attribute now can take multiple values and changed default value of display attribute to "initial"

### DIFF
--- a/src/iframe.tsx
+++ b/src/iframe.tsx
@@ -25,7 +25,7 @@ const Iframe: ComponentType<IIframe>
 		scrolling: scrolling || null,
 		allowpaymentrequest: allowpaymentrequest || null,
 		importance: importance || null,
-		sandbox: sandbox || null,
+		sandbox: (sandbox && [...sandbox].join(" ")) || null,
 		loading: loading || null,
 		styles: styles || null,
 		name: name || null,

--- a/src/iframe.tsx
+++ b/src/iframe.tsx
@@ -19,7 +19,7 @@ const Iframe: ComponentType<IIframe>
 		target: target || null,
 		style: {
 			position: position || null,
-			display: display || "block",
+			display: display || "initial",
 			overflow: overflow || null
 		},
 		scrolling: scrolling || null,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -5,7 +5,7 @@ export interface IIframe {
 	src?: string,
 	allowFullScreen?: boolean,
 	position?: "relative" | "absolute" | "fixed" | "sticky" | "static" | "inherit" | "initial" | "unset",
-	display?: "block" | "none" | "inline",
+	display?: "block" | "none" | "inline" | "initial",
 	height?: string,
 	width?: string,
 	loading?: "auto" | "eager" | "lazy",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+type SandboxAttributeValue = "allow-downloads-without-user-activation" | "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation" | "allow-top-navigation-by-user-activation";
+
 export interface IIframe {
 	url: string,
 	src?: string,
@@ -23,7 +25,7 @@ export interface IIframe {
 	ariaHidden?: boolean,
 	ariaLabel?: string,
 	ariaLabelledby?: string,
-	sandbox?: "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation" | "allow-top-navigation-by-user-activation",
+	sandbox?: SandboxAttributeValue | SandboxAttributeValue[],
 	allow?: string,
 	className?: string,
 	title?: string

--- a/types.d.ts
+++ b/types.d.ts
@@ -5,7 +5,7 @@ export interface IIframe {
 	src?: string,
 	allowFullScreen?: boolean,
 	position?: "relative" | "absolute" | "fixed" | "sticky" | "static" | "inherit" | "initial" | "unset",
-	display?: "block" | "none" | "inline",
+	display?: "block" | "none" | "inline" | "initial",
 	height?: string,
 	width?: string,
 	loading?: "auto" | "eager" | "lazy",

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,3 +1,5 @@
+type SandboxAttributeValue = "allow-downloads-without-user-activation" | "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation" | "allow-top-navigation-by-user-activation";
+
 export interface IIframe {
 	url: string,
 	src?: string,
@@ -23,7 +25,7 @@ export interface IIframe {
 	ariaHidden?: boolean,
 	ariaLabel?: string,
 	ariaLabelledby?: string,
-	sandbox?: "allow-forms" | "allow-modals" | "allow-orientation-lock" | "allow-pointer-lock" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-presentation" | "allow-same-origin" | "allow-scripts" | "allow-storage-access-by-user-activation" | "allow-top-navigation" | "allow-top-navigation-by-user-activation",
+	sandbox?: SandboxAttributeValue | SandboxAttributeValue[],
 	allow?: string,
 	className?: string,
 	title?: string


### PR DESCRIPTION
 As stated in [https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-referrer](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-referrer) the sandbox attribute can now take multiple argumens in the form of an array.
The array is converted a space-saparated list.

A missing value "allow-downloads-without-user-activation" was also added.

The display attribute doesn't accept "initial" as value, which is a value all css attributes can have. Here it is added. Also "initial" is always the default value for a attribute, so it was changed to be the default here too.
The previous default was "block", which is wrong accourding to [https://developer.mozilla.org/en-US/docs/Web/CSS/display#Specifications](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Specifications).